### PR TITLE
Fix pre-commit.ci hooks (shfmt, shellcheck)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,12 +42,15 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==22.12.0]
-  - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 3.0.0
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.9.0.2
     hooks:
       - id: shellcheck
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.6.0-1
+    hooks:
       - id: shfmt
-        args: ["-i", "2"]
+        args: ["-w", "-i", "2"]
   - repo: https://github.com/lovesegfault/beautysh
     rev: v6.2.1
     hooks:


### PR DESCRIPTION
Use [pre-commit-shfmt](https://github.com/scop/pre-commit-shfmt) and [shellcheck-py](https://github.com/shellcheck-py/shellcheck-py) as replacement for native installations.